### PR TITLE
Added Cistern.ValueLinq

### DIFF
--- a/BenchmarkConfig.cs
+++ b/BenchmarkConfig.cs
@@ -8,8 +8,8 @@ namespace linq_perf
     {
         public BenchmarkConfig()
         {
-            Add(JitOptimizationsValidator.FailOnError);
-            Add(MemoryDiagnoser.Default);
+            AddValidator(JitOptimizationsValidator.FailOnError);
+            AddDiagnoser(MemoryDiagnoser.Default);
         }
     }
 }

--- a/Benchmarks.CisternValueLinq.cs
+++ b/Benchmarks.CisternValueLinq.cs
@@ -1,0 +1,126 @@
+using BenchmarkDotNet.Attributes;
+using Cistern.ValueLinq;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace linq_perf
+{
+    public partial class WhereSelectBenchmarks
+    {
+        struct Mod10 : IFunc<int, bool> { public bool Invoke(int i) => i % 10 == 0; }
+        struct Add5 : IFunc<int, int> { public int Invoke(int i) => i + 5;  }
+
+        [Benchmark, BenchmarkCategory("ToList")]
+        public List<int> ValueLinqWhereSelectList()
+        {
+            var results = itemsList
+                .Where(i => i % 10 == 0)
+                .Select(i => i + 5)
+                .ToList();
+            return results;
+        }
+
+        [Benchmark, BenchmarkCategory("ToList")]
+        public List<int> ValueLinqWhereSelectListUsePool()
+        {
+            var results = itemsList
+                .Where(i => i % 10 == 0)
+                .Select(i => i + 5)
+                .ToListUsePool();
+            return results;
+        }
+
+        [Benchmark, BenchmarkCategory("ToList")]
+        public List<int> ValueLinqIFuncWhereSelectList()
+        {
+            var results = itemsList
+                .Where(new Mod10())
+                .Select(new Add5(), default(int))
+                .ToList();
+            return results;
+        }
+
+        [Benchmark, BenchmarkCategory("ToList")]
+        public List<int> ValueLinqIFuncWhereSelectListUsePool()
+        {
+            var results = itemsList
+                .Where(new Mod10())
+                .Select(new Add5(), default(int))
+                .ToListUsePool();
+            return results;
+        }
+
+        [Benchmark, BenchmarkCategory("ToArray")]
+        public int[] ValueLinqWhereSelectArray()
+        {
+            var results = itemsArray
+                .Where(i => i % 10 == 0)
+                .Select(i => i + 5)
+                .ToArray();
+            return results;
+        }
+
+        [Benchmark, BenchmarkCategory("ToArray")]
+        public int[] ValueLinqWhereSelectArrayUsePool()
+        {
+            var results = itemsArray
+                .Where(i => i % 10 == 0)
+                .Select(i => i + 5)
+                .ToArrayUsePool();
+            return results;
+        }
+        [Benchmark, BenchmarkCategory("ToArray")]
+        public int[] ValueLinqIFuncWhereSelectArray()
+        {
+            var results = itemsArray
+                .Where(new Mod10())
+                .Select(new Add5(), default(int))
+                .ToArray();
+            return results;
+        }
+
+        [Benchmark, BenchmarkCategory("ToArray")]
+        public int[] ValueLinqIFuncWhereSelectArrayUsePool()
+        {
+            var results = itemsArray
+                .Where(new Mod10())
+                .Select(new Add5(), default(int))
+                .ToArrayUsePool();
+            return results;
+        }
+    }
+
+    public partial class FirstBenchmarks
+    {
+        struct Times2Eq100000 : IFunc<int, bool> { public bool Invoke(int i) => (i * 2) == 100000; }
+
+
+        [Benchmark]
+        public int ValueLinqFirstList()
+        {
+            int result = itemsList.First(i => (i * 2) == 100000);
+            return result;
+        }
+
+        [Benchmark]
+        public int ValueLinqIFuncFirstList()
+        {
+            int result = itemsList.Where(new Times2Eq100000()).First();
+            return result;
+        }
+
+        [Benchmark]
+        public int ValueLinqFirstArray()
+        {
+            int result = itemsArray.First(i => (i * 2) == 100000);
+            return result;
+        }
+
+        [Benchmark]
+        public int ValueLinqIFuncFirstArray()
+        {
+            int result = itemsArray.Where(new Times2Eq100000()).First();
+            return result;
+        }
+    }
+}

--- a/Benchmarks.cs
+++ b/Benchmarks.cs
@@ -1,16 +1,19 @@
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
 using JM.LinqFaster;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace linq_perf
 {
-    [Config(typeof(BenchmarkConfig))]
-    public class WhereSelectBenchmarks
+    [MemoryDiagnoser]
+    [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+    [CategoriesColumn]
+    public partial class WhereSelectBenchmarks
     {
         private static readonly List<int> itemsList = Enumerable.Range(0, 100000).ToList();
 
-        [Benchmark(Baseline = true)]
+        [Benchmark(Baseline = true), BenchmarkCategory("ToList")]
         public List<int> IterativeWhereSelectList()
         {
             var results = new List<int>();
@@ -24,7 +27,7 @@ namespace linq_perf
             return results;
         }
 
-        [Benchmark]
+        [Benchmark, BenchmarkCategory("ToList")]
         public List<int> LinqWhereSelectList()
         {
             var results = itemsList
@@ -34,7 +37,7 @@ namespace linq_perf
             return results;
         }
 
-        [Benchmark]
+        [Benchmark, BenchmarkCategory("ToList")]
         public List<int> LinqFasterWhereSelectList()
         {
             var results = itemsList
@@ -44,7 +47,7 @@ namespace linq_perf
 
         private static readonly int[] itemsArray = Enumerable.Range(0, 100000).ToArray();
 
-        [Benchmark]
+        [Benchmark(Baseline = true), BenchmarkCategory("ToArray")]
         public int[] IterativeWhereSelectArray()
         {
             var accumulator = new List<int>();
@@ -59,7 +62,7 @@ namespace linq_perf
             return results;
         }
 
-        [Benchmark]
+        [Benchmark, BenchmarkCategory("ToArray")]
         public int[] LinqWhereSelectArray()
         {
             var results = itemsArray
@@ -69,7 +72,7 @@ namespace linq_perf
             return results;
         }
 
-        [Benchmark]
+        [Benchmark, BenchmarkCategory("ToArray")]
         public int[] LinqFasterWhereSelectArray()
         {
             var results = itemsArray
@@ -78,8 +81,8 @@ namespace linq_perf
         }
     }
 
-    [Config(typeof(BenchmarkConfig))]
-    public class FirstBenchmarks
+    [MemoryDiagnoser]
+    public partial class FirstBenchmarks
     {
         private static readonly List<int> itemsList = Enumerable.Range(0, 100000).ToList();
 

--- a/Program.cs
+++ b/Program.cs
@@ -9,8 +9,8 @@ namespace linq_perf
     {
         static void Main(string[] args)
         {
-            BenchmarkRunner.Run<WhereSelectBenchmarks>();
-            // BenchmarkRunner.Run<FirstBenchmarks>();
+            //BenchmarkRunner.Run<WhereSelectBenchmarks>();
+            BenchmarkRunner.Run<FirstBenchmarks>();
         }
     }
 }

--- a/linq-perf.csproj
+++ b/linq-perf.csproj
@@ -2,11 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.11.5" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="Cistern.ValueLinq" Version="0.1.9" />
     <PackageReference Include="LinqFaster" Version="1.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Hi!

Given that you're not even watching your own project, I'm not sure if you will even get this PR, but anyway...

OK; I've been working on a "compatible"(ish) Linq-clone, which uses values types, and hence achieves runtime "stream fusion", which when coupled with "value-type funcs" can achieve near hand-coded performance.

It's here: https://github.com/manofstick/Cistern.ValueLinq

Haven't yet got to 100% functionality of System.Linq, but getting close. And then it's a matter of extending with additional options to allow more optimizations (such as adding a flag for predicates to mark then as pure, which allows for some optimizations which are avoided in case they are not - there is quite a long discussion about this with a FirstOfDefault after OrderBy optimization that was added to .net core, and later removed due to this - see https://www.meziantou.net/don-t-use-method-with-side-effect-in-linq.htm)

I have already implemented some add-on functions, such as ToListUsePool, which uses the ArrayPool objects, and there's lots of other goodies in there as well (SIMD for Span-able storage, take/skip/reverse for random accessable storage, etc....)

Anyway, hope you are interested to some degree... No-one else is :-)

|                                Method | Categories |     Mean |    Error |   StdDev |   Median | Ratio | RatioSD |    Gen 0 |    Gen 1 |    Gen 2 | Allocated |
|-------------------------------------- |----------- |---------:|---------:|---------:|---------:|------:|--------:|---------:|---------:|---------:|----------:|
|              ValueLinqWhereSelectList |     ToList | 622.0 us | 12.25 us | 24.17 us | 628.8 us |  1.01 |    0.06 |  30.2734 |   2.9297 |        - | 128.32 KB |
|       ValueLinqWhereSelectListUsePool |     ToList | 558.4 us | 10.96 us | 21.64 us | 560.4 us |  0.90 |    0.06 |   8.7891 |   0.9766 |        - |  39.12 KB |
|         ValueLinqIFuncWhereSelectList |     ToList | 375.5 us |  7.42 us | 15.97 us | 381.4 us |  0.61 |    0.04 |  30.7617 |   1.4648 |        - | 128.32 KB |
|  ValueLinqIFuncWhereSelectListUsePool |     ToList | 368.8 us |  7.33 us | 15.31 us | 372.6 us |  0.60 |    0.03 |   9.2773 |   1.4648 |        - |  39.12 KB |
|              IterativeWhereSelectList |     ToList | 617.7 us | 12.24 us | 27.63 us | 626.5 us |  1.00 |    0.00 |  30.2734 |   2.9297 |        - | 128.32 KB |
|                   LinqWhereSelectList |     ToList | 632.4 us | 12.47 us | 22.48 us | 641.0 us |  1.02 |    0.06 |  30.2734 |   9.7656 |        - | 128.47 KB |
|             LinqFasterWhereSelectList |     ToList | 631.2 us | 12.60 us | 27.67 us | 643.4 us |  1.02 |    0.07 |  30.2734 |   2.9297 |        - | 128.32 KB |
|                                       |            |          |          |          |          |       |         |          |          |          |           |
|             ValueLinqWhereSelectArray |    ToArray | 587.5 us | 11.57 us | 19.01 us | 594.0 us |  1.63 |    0.10 |  24.4141 |   0.9766 |        - | 103.26 KB |
|      ValueLinqWhereSelectArrayUsePool |    ToArray | 571.8 us | 11.24 us | 19.09 us | 575.7 us |  1.59 |    0.09 |   8.7891 |   0.9766 |        - |  39.09 KB |
|        ValueLinqIFuncWhereSelectArray |    ToArray | 521.7 us | 10.29 us | 24.67 us | 528.3 us |  1.44 |    0.10 |  24.4141 |   0.9766 |        - | 103.26 KB |
| ValueLinqIFuncWhereSelectArrayUsePool |    ToArray | 381.8 us |  7.27 us |  8.66 us | 383.4 us |  1.06 |    0.05 |   9.2773 |   0.9766 |        - |  39.09 KB |
|             IterativeWhereSelectArray |    ToArray | 362.0 us |  7.20 us | 15.50 us | 364.1 us |  1.00 |    0.00 |  40.5273 |   0.4883 |        - | 167.41 KB |
|                  LinqWhereSelectArray |    ToArray | 597.7 us | 11.41 us | 14.83 us | 602.9 us |  1.66 |    0.08 |  24.4141 |        - |        - |  103.8 KB |
|            LinqFasterWhereSelectArray |    ToArray | 630.0 us | 12.53 us | 26.16 us | 635.5 us |  1.74 |    0.10 | 124.0234 | 124.0234 | 124.0234 | 429.73 KB |


|                   Method |      Mean |     Error |    StdDev |    Median | Ratio | RatioSD | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------- |----------:|----------:|----------:|----------:|------:|--------:|------:|------:|------:|----------:|
|       ValueLinqFirstList | 203.35 us |  0.148 us |  0.115 us | 203.35 us |  0.94 |    0.03 |     - |     - |     - |         - |
|  ValueLinqIFuncFirstList |  51.17 us |  0.135 us |  0.120 us |  51.11 us |  0.23 |    0.01 |     - |     - |     - |         - |
|      ValueLinqFirstArray | 186.75 us |  0.664 us |  0.555 us | 186.45 us |  0.86 |    0.03 |     - |     - |     - |         - |
| ValueLinqIFuncFirstArray |  52.32 us |  0.881 us |  0.824 us |  52.73 us |  0.24 |    0.01 |     - |     - |     - |         - |
|       IterativeFirstList | 217.48 us |  4.334 us |  8.656 us | 220.98 us |  1.00 |    0.00 |     - |     - |     - |         - |
|            LinqFirstList | 669.73 us | 13.205 us | 28.141 us | 681.17 us |  3.08 |    0.19 |     - |     - |     - |      40 B |
|      LinqFasterFirstList | 172.44 us |  3.435 us |  9.403 us | 175.05 us |  0.79 |    0.05 |     - |     - |     - |         - |
|      IterativeFirstArray |  58.46 us |  1.150 us |  2.215 us |  59.23 us |  0.27 |    0.02 |     - |     - |     - |         - |
|           LinqFirstArray | 521.36 us | 10.333 us | 22.898 us | 528.89 us |  2.41 |    0.13 |     - |     - |     - |      32 B |
|     LinqFasterFirstArray | 169.32 us |  3.326 us |  6.795 us | 171.79 us |  0.78 |    0.04 |     - |     - |     - |         - |